### PR TITLE
add test_regressor_prediction_range

### DIFF
--- a/sklearn/ensemble/tests/test_forest.py
+++ b/sklearn/ensemble/tests/test_forest.py
@@ -1367,3 +1367,36 @@ def test_little_tree_with_small_max_samples(ForestClass):
 
     msg = "Tree without `max_samples` restriction should have more nodes"
     assert tree1.node_count > tree2.node_count, msg
+
+
+def test_rf_regressor_prediction_range():
+    # Create a Random Number Generator with 42 as a fixed seed.
+    rng = np.random.RandomState(42)
+    n_samples = 100
+    n_features = 1
+
+    X_train = rng.normal(size=(n_samples, n_features))
+    y_train = rng.normal(size=n_samples)
+
+    rfr = RandomForestRegressor(random_state=42)
+    rfr.fit(X_train, y_train)
+
+    # TODO: np.min() and np.max() to measure the minimum and
+    # maximum values of the training set target values y_train.
+    min_val = np.min(y_train)
+    max_val = np.max(y_train)
+
+    # TODO: generate some random data X_test with the same number
+    # of features.
+
+    X_test = rng.normal(size=(30, n_features))
+
+    # TODO: compute the model predictions on the test data:
+    # rfr.predict(X_test) and store the results in a variable y_preds.
+
+    y_preds = rfr.predict(X_test)
+
+    # TODO: check that all the values in y_preds lie between the minimum
+    # and maximum values of y_train.
+    msg = "Predictions outside of range"
+    assert (y_preds <= max_val).all() and (y_preds >= min_val).all(), msg


### PR DESCRIPTION
#### Reference Issues/PRs

Test merge for Paris sprint.

#### What does this implement/fix? Explain your changes.

Adding a test to check if the regressor prediction of a Random Forest stays in training set range.

#### Any other comments?
